### PR TITLE
Update env.mjs

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -13,7 +13,7 @@ const server = z.object({
       : z.string().min(1).optional(),
   NEXTAUTH_URL: z
     .preprocess(
-      (str) => "https://" + process.env.RAILWAY_STATIC_URL ?? str,
+      (str) => (process.env.RAILWAY_STATIC_URL ? "https://" + process.env.RAILWAY_STATIC_URL : str),
       z.string().url()
     )
     .transform((x) => {


### PR DESCRIPTION
When `process.env.RAILWAY_STATIC_URL` is undefined, the code becomes `"https://undefined" ?? str`, and it returns `https://undefined`.